### PR TITLE
Fix typos and enhance SDF test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-    f = scripts/helper.sh
+    f=scripts/helper.sh
     chmod +x $f
     ./$f

--- a/app.js
+++ b/app.js
@@ -79,7 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
         });
 
     videoElement.addEventListener('click', handleInteraction);
-    videoElement.addEventListenlistMolecules('touchstart', (e) => {
+    videoElement.addEventListener('touchstart', (e) => {
         e.preventDefault(); // Prevent default touch behavior
         handleInteraction(e);
     });

--- a/dock/rcsb_pdb.py
+++ b/dock/rcsb_pdb.py
@@ -1,4 +1,4 @@
-mport requests
+import requests
 from pathlib import Path
 
 import chem

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,6 @@
 import pytest
 from pathlib import Path
+from rdkit import Chem
 from sdf import sdf
 
 @pytest.fixture
@@ -16,5 +17,10 @@ def test_sdf_file_creation(smiles, cleanup_sdf):
     Path(directory).mkdir(exist_ok=True)
 
     filepath = sdf(smiles, directory, overwrite=True)
-    
+
     assert Path(filepath).exists(), f"SDF file {filepath} was not created."
+
+    supplier = Chem.SDMolSupplier(filepath)
+    mol = supplier[0]
+    assert mol is not None, "Failed to read molecule from SDF"
+    assert mol.GetProp("SMILES") == smiles


### PR DESCRIPTION
## Summary
- fix rcsb_pdb import typo
- correct touchstart handler in app.js
- fix README variable assignment
- check SMILES property in SDF conversion test

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for rdkit and other modules)*

------
https://chatgpt.com/codex/tasks/task_e_68594bc1a7cc832eafa15b914a375d2c